### PR TITLE
feat(event): adiciona paginação ao endpoint de listagem de eventos

### DIFF
--- a/src/main/java/br/com/carloslonghi/eventflow/api/core/gateway/EventGateway.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/core/gateway/EventGateway.java
@@ -1,12 +1,11 @@
 package br.com.carloslonghi.eventflow.api.core.gateway;
 
 import br.com.carloslonghi.eventflow.api.core.domain.Event;
-
-import java.util.List;
+import br.com.carloslonghi.eventflow.api.core.shared.PageResult;
 
 public interface EventGateway {
 
     Event createEvent(Event event);
 
-    List<Event> listEvents();
+    PageResult<Event> listEvents(int pageNumber, int pageSize);
 }

--- a/src/main/java/br/com/carloslonghi/eventflow/api/core/shared/PageResult.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/core/shared/PageResult.java
@@ -1,0 +1,12 @@
+package br.com.carloslonghi.eventflow.api.core.shared;
+
+import java.util.List;
+
+public record PageResult<T>(
+        List<T> content,
+        int pageNumber,
+        int pageSize,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/br/com/carloslonghi/eventflow/api/core/usecases/ListEventsUseCase.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/core/usecases/ListEventsUseCase.java
@@ -1,10 +1,9 @@
 package br.com.carloslonghi.eventflow.api.core.usecases;
 
 import br.com.carloslonghi.eventflow.api.core.domain.Event;
-
-import java.util.List;
+import br.com.carloslonghi.eventflow.api.core.shared.PageResult;
 
 public interface ListEventsUseCase {
 
-    List<Event> execute();
+    PageResult<Event> execute(int pageNumber, int pageSize);
 }

--- a/src/main/java/br/com/carloslonghi/eventflow/api/core/usecases/ListEventsUseCaseImpl.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/core/usecases/ListEventsUseCaseImpl.java
@@ -2,8 +2,7 @@ package br.com.carloslonghi.eventflow.api.core.usecases;
 
 import br.com.carloslonghi.eventflow.api.core.domain.Event;
 import br.com.carloslonghi.eventflow.api.core.gateway.EventGateway;
-
-import java.util.List;
+import br.com.carloslonghi.eventflow.api.core.shared.PageResult;
 
 public class ListEventsUseCaseImpl implements ListEventsUseCase {
 
@@ -14,7 +13,7 @@ public class ListEventsUseCaseImpl implements ListEventsUseCase {
     }
 
     @Override
-    public List<Event> execute() {
-        return eventGateway.listEvents();
+    public PageResult<Event> execute(int pageNumber, int pageSize) {
+        return eventGateway.listEvents(pageNumber, pageSize);
     }
 }

--- a/src/main/java/br/com/carloslonghi/eventflow/api/infra/gateway/EventRepositoryGateway.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/infra/gateway/EventRepositoryGateway.java
@@ -2,14 +2,14 @@ package br.com.carloslonghi.eventflow.api.infra.gateway;
 
 import br.com.carloslonghi.eventflow.api.core.domain.Event;
 import br.com.carloslonghi.eventflow.api.core.gateway.EventGateway;
+import br.com.carloslonghi.eventflow.api.core.shared.PageResult;
 import br.com.carloslonghi.eventflow.api.infra.mapper.EventEntityMapper;
 import br.com.carloslonghi.eventflow.api.infra.persistence.EventEntity;
 import br.com.carloslonghi.eventflow.api.infra.persistence.EventRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -28,9 +28,16 @@ public class EventRepositoryGateway implements EventGateway {
     }
 
     @Override
-    public List<Event> listEvents() {
-        return eventRepository.findAll().stream()
-                .map(eventEntityMapper::toDomain)
-                .collect(Collectors.toList());
+    public PageResult<Event> listEvents(int pageNumber, int pageSize) {
+        PageRequest pageable = PageRequest.of(pageNumber, pageSize);
+        Page<EventEntity> result = eventRepository.findAll(pageable);
+
+        return new PageResult<>(
+                result.stream().map(eventEntityMapper::toDomain).toList(),
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages()
+        );
     }
 }

--- a/src/main/java/br/com/carloslonghi/eventflow/api/infra/presentation/EventController.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/infra/presentation/EventController.java
@@ -1,15 +1,17 @@
 package br.com.carloslonghi.eventflow.api.infra.presentation;
 
 import br.com.carloslonghi.eventflow.api.core.domain.Event;
+import br.com.carloslonghi.eventflow.api.core.shared.PageResult;
 import br.com.carloslonghi.eventflow.api.core.usecases.CreateEventUseCase;
 import br.com.carloslonghi.eventflow.api.core.usecases.ListEventsUseCase;
 import br.com.carloslonghi.eventflow.api.infra.dtos.EventDto;
 import br.com.carloslonghi.eventflow.api.infra.mapper.EventDtoMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/event")
@@ -30,9 +32,13 @@ public class EventController {
     }
 
     @GetMapping
-    public List<EventDto> getAllEvents() {
-        return listEventsUseCase.execute().stream()
-                .map(eventDtoMapper::toDto)
-                .collect(Collectors.toList());
+    public Page<EventDto> listEvents(Pageable pageable) {
+        PageResult<Event> result = listEventsUseCase.execute(pageable.getPageNumber(), pageable.getPageSize());
+
+        return new PageImpl<>(
+                result.content().stream().map(eventDtoMapper::toDto).toList(),
+                PageRequest.of(result.pageNumber(), result.pageSize()),
+                result.totalElements()
+        );
     }
 }


### PR DESCRIPTION
Este PR introduz suporte a paginação no endpoint de listagem de eventos, melhorando a performance e a escalabilidade da aplicação ao lidar com grandes volumes de dados.

Principais mudanças:

**Core**

- Atualizado `EventGateway` e `ListEventsUseCase` para suportar paginação via `PageResult`.
- Ajustada a implementação `ListEventsUseCaseImpl` para delegar paginação ao gateway.

**Infra**

- Modificado `EventRepositoryGateway` para retornar `PageResult` com paginação usando `PageRequest` do Spring Data.

**API (Apresentação)**

- Alterado `EventController` para expor endpoint paginado (`Page<EventDto>`), aceitando parâmetros de `Pageable` para paginação.

**Motivação**

- Antes, o endpoint retornava todos os eventos de uma vez, o que poderia causar problemas de performance.  
- Com a paginação, os clientes podem consumir os eventos em páginas, aumentando a eficiência e melhorando a experiência do usuário.

**Endpoints atualizados:**

- GET /api/v1/event → Listar eventos com suporte a paginação (parâmetros: page, size)