### PR TITLE
refactor(infra): reorganiza DTOs e adiciona ApiResponse genérico para consistência

### DIFF
--- a/src/main/java/br/com/carloslonghi/eventflow/api/infra/gateway/EventGatewayImpl.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/infra/gateway/EventGatewayImpl.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class EventRepositoryGateway implements EventGateway {
+public class EventGatewayImpl implements EventGateway {
 
     private final EventRepository eventRepository;
     private final EventEntityMapper eventEntityMapper;

--- a/src/main/java/br/com/carloslonghi/eventflow/api/infra/mapper/EventDtoMapper.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/infra/mapper/EventDtoMapper.java
@@ -1,7 +1,7 @@
 package br.com.carloslonghi.eventflow.api.infra.mapper;
 
 import br.com.carloslonghi.eventflow.api.core.domain.Event;
-import br.com.carloslonghi.eventflow.api.infra.dtos.EventDto;
+import br.com.carloslonghi.eventflow.api.infra.presentation.dtos.EventDto;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")

--- a/src/main/java/br/com/carloslonghi/eventflow/api/infra/presentation/EventController.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/infra/presentation/EventController.java
@@ -4,14 +4,21 @@ import br.com.carloslonghi.eventflow.api.core.domain.Event;
 import br.com.carloslonghi.eventflow.api.core.shared.PageResult;
 import br.com.carloslonghi.eventflow.api.core.usecases.CreateEventUseCase;
 import br.com.carloslonghi.eventflow.api.core.usecases.ListEventsUseCase;
-import br.com.carloslonghi.eventflow.api.infra.dtos.EventDto;
+import br.com.carloslonghi.eventflow.api.infra.presentation.dtos.EventDto;
 import br.com.carloslonghi.eventflow.api.infra.mapper.EventDtoMapper;
+import br.com.carloslonghi.eventflow.api.infra.presentation.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/event")
@@ -24,11 +31,17 @@ public class EventController {
     private final EventDtoMapper eventDtoMapper;
 
     @PostMapping
-    public EventDto createEvent(@RequestBody EventDto eventDto) {
+    public ResponseEntity<ApiResponse<EventDto>> createEvent(@RequestBody EventDto eventDto) {
         Event event = eventDtoMapper.toDomain(eventDto);
         Event eventCreated = createEventUseCase.execute(event);
 
-        return eventDtoMapper.toDto(eventCreated);
+        ApiResponse<EventDto> response = new ApiResponse<>(
+                "Evento criado com sucesso",
+                eventDtoMapper.toDto(eventCreated),
+                Instant.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @GetMapping

--- a/src/main/java/br/com/carloslonghi/eventflow/api/infra/presentation/dtos/EventDto.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/infra/presentation/dtos/EventDto.java
@@ -1,4 +1,4 @@
-package br.com.carloslonghi.eventflow.api.infra.dtos;
+package br.com.carloslonghi.eventflow.api.infra.presentation.dtos;
 
 import br.com.carloslonghi.eventflow.api.core.enums.EventType;
 

--- a/src/main/java/br/com/carloslonghi/eventflow/api/infra/presentation/response/ApiResponse.java
+++ b/src/main/java/br/com/carloslonghi/eventflow/api/infra/presentation/response/ApiResponse.java
@@ -1,0 +1,10 @@
+package br.com.carloslonghi.eventflow.api.infra.presentation.response;
+
+import java.time.Instant;
+
+public record ApiResponse<T>(
+        String message,
+        T data,
+        Instant timestamp
+) {
+}


### PR DESCRIPTION
**Descrição do PR:**
Este PR realiza ajustes estruturais na camada de apresentação da aplicação, visando maior clareza e padronização nas respostas da API.

**Principais mudanças:**

- EventDto movido de infra.dtos para infra.presentation.dtos, alinhando a estrutura com a responsabilidade de apresentação.
- Atualização do EventDtoMapper para refletir o novo package.
- Criação de ApiResponse<T> como envelope genérico para padronizar respostas da API.
- Ajuste do EventController para retornar ResponseEntity<ApiResponse<EventDto>> na criação de eventos, incluindo mensagem e timestamp.
- Renomeação de EventRepositoryGateway para EventGatewayImpl para melhor consistência de nomenclatura.

Essas alterações trazem uma estrutura mais clara, alinhada à Clean Architecture, e melhoram a padronização das respostas expostas pela API.